### PR TITLE
SWAT-2985:[Anaplan Write] Could not find separator in file: /apps/snplogic_workspace/sl_pipe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.anaplan.client</groupId>
+    <groupId>com.snaplogic</groupId>
     <artifactId>anaplan-connect</artifactId>
-    <version>1.4.4.4</version>
+    <version>1.4.4.5</version>
     <name>Anaplan Connect</name>
 
     <properties>

--- a/src/main/java/com/anaplan/client/ServerFile.java
+++ b/src/main/java/com/anaplan/client/ServerFile.java
@@ -311,10 +311,7 @@ public class ServerFile extends NamedObject {
                 sourceFile.readFully(buffer, 0, size);
                 //reading the last index of the separator
                 int separatorLastIndex = lastIndexOf(buffer, data.getSeparator());
-                // Throw an exception if we don't find a separator in the first chunk
-                if ((totalReadSoFar == 0) && (separatorLastIndex == -1)) {
-                    throw new ParseCSVError(source.getAbsolutePath(), data.getSeparator());
-                }
+                // Throw an exception if we don't find a separator in the first gichunk
                 //determining the byte offset based on UTF-16LE encoding
                 int offset = data.getEncoding().equalsIgnoreCase("UTF-16LE") ? 2 : 1;
                 //calculating the size of byte array to load the bytes until the last index of separator
@@ -325,6 +322,10 @@ public class ServerFile extends NamedObject {
                 System.arraycopy(buffer, 0, finalBuffer, 0, finalSize);
                 //calculating the total read size from the file
                 totalReadSoFar += finalSize;
+
+                if ((chunkIterator.hasNext() && finalBuffer.length == 0) || buffer.length == 0) {
+                    throw new ParseCSVError(source.getAbsolutePath(), data.getSeparator());
+                }
                 //checking if there is another chunk to decide if to upload the newly created buffer or existing buffer.
                 //existing buffer will be uploaded in case of last chunk
                 if (chunkIterator.hasNext()) {

--- a/src/main/java/com/anaplan/client/ServerFile.java
+++ b/src/main/java/com/anaplan/client/ServerFile.java
@@ -323,6 +323,8 @@ public class ServerFile extends NamedObject {
                 //calculating the total read size from the file
                 totalReadSoFar += finalSize;
 
+                // finalBuffer or buffer size can be 0 when we don' find valid
+                // separator in the stream. That's why throwing error.
                 if ((chunkIterator.hasNext() && finalBuffer.length == 0) || buffer.length == 0) {
                     throw new ParseCSVError(source.getAbsolutePath(), data.getSeparator());
                 }

--- a/src/main/java/com/anaplan/client/ServerFile.java
+++ b/src/main/java/com/anaplan/client/ServerFile.java
@@ -323,7 +323,7 @@ public class ServerFile extends NamedObject {
                 //calculating the total read size from the file
                 totalReadSoFar += finalSize;
 
-                // finalBuffer or buffer size can be 0 when we don' find valid
+                // finalBuffer or buffer size can be 0 when we don't find a valid
                 // separator in the stream. That's why throwing error.
                 if ((chunkIterator.hasNext() && finalBuffer.length == 0) || buffer.length == 0) {
                     throw new ParseCSVError(source.getAbsolutePath(), data.getSeparator());


### PR DESCRIPTION
SWAT-2985:[Anaplan Write] Could not find separator in file: /apps/snplogic_workspace/sl_pipe

This is  a regression caused by SWAT-2888. As part of SWAT-2888, when there is no separator available in a chunk we are throwing an error assuming we may get Index out of bound exception. As part of this , we were only checking whether separator exist or not. If not, we were throwing exception.

But for single column file which can be <10MB file, we are not getting Index out of bound exception even though we don't have the separator as the data was computed to single chunk and we were sending complete data to API .

So as part of this fix, we are checking the buffer size is > 0 or not(buffer size is decided based on seperator for large(>10MB) files). If the buffer size is > 0 then , we are uploading the data to anaplan. If we have bufferSize == 0 or FinalBufferSize==0(this is used in case of multiple chunks), then we are throwing exception now.

This will fix problem for Single column files and also for empty files. With this fix, we are not breaking any previous fixes like SWAT-2888 and SNAP-7273.

Here are the few screenshots : 
SNAP-7273 Scenario(With empty data) after this change : 

![image](https://user-images.githubusercontent.com/50152071/122763444-f79e5c00-d2bb-11eb-8491-d7898b586d3f.png)

SWAT-2888 scenario with valid seperator  : 
![image](https://user-images.githubusercontent.com/50152071/122763582-1dc3fc00-d2bc-11eb-9e0c-c3acfb62aeed.png)

SWAT-2888 scenario with invalid seperator  :+1: 
![image](https://user-images.githubusercontent.com/50152071/122763642-33d1bc80-d2bc-11eb-9da6-4fcfe0ef5f3f.png)

SWAT-2985 after Fix  for upload (with Single column data) 
![image](https://user-images.githubusercontent.com/50152071/122763728-4c41d700-d2bc-11eb-9575-9ba61abd18c9.png)

SWAT-2985 after fix for Write snap(With Single column data)
![image](https://user-images.githubusercontent.com/50152071/122763883-78f5ee80-d2bc-11eb-9623-e6f57b946789.png)




